### PR TITLE
feat: add filepath field to webhook payload

### DIFF
--- a/src/services/PayloadService.ts
+++ b/src/services/PayloadService.ts
@@ -5,6 +5,7 @@ export class PayloadService {
   static createPayload(
     content: string,
     filename: string,
+    filepath: string,
     attachments: any[],
     selectedText?: string | null,
     variableNote?: VariableNote | null,
@@ -17,6 +18,7 @@ export class PayloadService {
       payload = {
         content: selectedText || content,
         filename,
+        filepath,
         timestamp: Date.now(),
         attachments
       };
@@ -28,6 +30,7 @@ export class PayloadService {
         ...frontmatter,
         content: noteContent,
         filename,
+        filepath,
         timestamp: Date.now(),
         attachments
       };

--- a/src/services/WebhookService.ts
+++ b/src/services/WebhookService.ts
@@ -60,6 +60,7 @@ export class WebhookService {
       const payload = PayloadService.createPayload(
         content, 
         filename, 
+        '/' + file.path,
         attachments, 
         effectiveSelection || null, 
         variableNote,

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Attachment {
 export interface WebhookPayload {
   content: string;
   filename: string;
+  filepath: string;
   timestamp: number;
   attachments: Attachment[];
   [key: string]: any;


### PR DESCRIPTION
## 📝 Description
This PR adds a `filepath` field to the webhook payload, providing the complete file path from the vault root with a leading slash.

## 🎯 Motivation
Currently, the webhook payload only includes the `filename` (e.g., "note.md"), but not the full path within the vault. This makes it difficult for webhook endpoints to understand the file's location and organize content based on folder structure.

## 🔧 Changes
- Add `filepath` field to `WebhookPayload` interface in `src/types.ts`
- Update `PayloadService.createPayload()` to accept and include filepath parameter  
- Modify `WebhookService` to pass the complete file path with leading slash

## 📊 Example
**Before:**
```json
{
  "content": "...",
  "filename": "note.md", 
  "timestamp": 1234567890
}
```

**After:**
```json
{
  "content": "...",
  "filename": "note.md",
  "filepath": "/folder1/subfolder/note.md",
  "timestamp": 1234567890
}
```

## ✅ Testing
- [x] Code compiles successfully
- [x] Tested with webhook endpoints to verify filepath is included
- [x] Verified format includes leading slash as expected

## 🔄 Backward Compatibility
This change is fully backward compatible - it only adds a new field without modifying existing ones.